### PR TITLE
remove the upper bound of requires-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyproject-flake8
+          python -m pip install flake8-pyproject
       - name: Check
-        run: pflake8 -v src
+        run: flake8p -v src
   isort:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/checks.sh
+++ b/checks.sh
@@ -3,6 +3,6 @@ set -eoux pipefail
 
 python -m pytest src -vv
 python -m black --check src
-python -m pflake8 src
+python -m flake8p src
 python -m isort --check src
 python -m mypy src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "flake8>=6.1.0",
     "isort>=5.12.0",
     "mypy>=1.6.1",
-    "pyproject-flake8>=6.1.0",
+    "flake8-pyproject>=1.2.4",
     "pytest>=7.4.3",
 ]
 mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "unopt"
 description = "Utility functions to unwrap Optional values"
 readme = "README.md"
-requires-python = ">=3.8, <=3.13"
+requires-python = ">=3.8"
 license = {text = "Apache Software License 2.0"}
 authors = [
     {name = "Yusuke Oda", email = "odashi@predicate.jp"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "unopt"
 description = "Utility functions to unwrap Optional values"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "Apache Software License 2.0"}
+license = "MIT"
 authors = [
     {name = "Yusuke Oda", email = "odashi@predicate.jp"},
 ]
@@ -19,7 +19,6 @@ keywords = [
     "rust",
 ]
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/src/unopt/_version.py
+++ b/src/unopt/_version.py
@@ -3,4 +3,5 @@
 DON'T TOUCH THIS FILE.
 This file is replaced during the release process.
 """
+
 __version__ = "0.0.0a0"


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

@odashi thank you for this kind of pypi module. I wonder why this kind of work is not a part of standard module yet, as typing is more and more important recently and type-checkers do not understand Optional as expression form.[^1]

We are now using Python 3.13.5 (which is shipped by Debian 13), but installing unopt-py was rejected. I fixed some parts. Also I modernized a small part of the code.

# Details

- add a blank line in _version.py so that black does not complain
    - Had `1 file would be reformatted, 3 files would be left unchanged` error with black 25.1.
- migrate to flake8-pyproject
    - pyproject-flake8 has hard dependency of flake8. This can be problems when we want to use more recent version of flake8.
- remove the upper bound of requires-python
    - (the main content of the pull request, see above)
- use proper license expression and remove contradictory line
    - Recently license value should be SPDX-expression. also pyproject/toml showed MIT and Apache, so I kept MIT (which is mentioned in LICENSE file) and removed Apache.

[^1]: I mean with unopt-py, `unwrap(n)+1` expression works without assert statement.